### PR TITLE
Handle null inputs in EmergencyDataService

### DIFF
--- a/OtChaim.Application.Tests/Services/EmergencyDataServiceTests.cs
+++ b/OtChaim.Application.Tests/Services/EmergencyDataServiceTests.cs
@@ -1,93 +1,104 @@
+using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
 using FluentAssertions;
 using NSubstitute;
 using OtChaim.Application.Services;
 using OtChaim.Domain.EmergencyEvents;
 using OtChaim.Domain.Users;
-using System.Collections.ObjectModel;
 
 namespace OtChaim.Application.Tests.Services;
 
 [TestFixture]
 public class EmergencyDataServiceTests
 {
+    private IEmergencyRepository _emergencyRepository = null!;
+    private IUserRepository _userRepository = null!;
     private EmergencyDataService _service = null!;
 
     [SetUp]
     public void Setup()
     {
-        _service = new EmergencyDataService(Substitute.For<IEmergencyRepository>(), Substitute.For<IUserRepository>());
+        _emergencyRepository = Substitute.For<IEmergencyRepository>();
+        _userRepository = Substitute.For<IUserRepository>();
+        _service = new EmergencyDataService(_emergencyRepository, _userRepository);
     }
 
     [Test]
     public void Constructor_ShouldInitializeService()
     {
-        // Assert
         _service.Should().NotBeNull();
     }
 
     [Test]
-    public void LoadActiveEmergenciesAsync_ShouldReturnEmptyCollection()
+    public async Task LoadActiveEmergenciesAsync_WhenRepositoryReturnsEmptyCollection_ShouldLeaveCollectionEmpty()
     {
-        // Arrange
         var emergencies = new ObservableCollection<Emergency>();
 
-        // Act
-        Task result = _service.LoadActiveEmergenciesAsync(emergencies);
+        _emergencyRepository.GetActiveAsync()
+            .Returns(Task.FromResult<IReadOnlyList<Emergency>>(Array.Empty<Emergency>()));
 
-        // Assert
-        result.Should().NotBeNull();
+        await _service.LoadActiveEmergenciesAsync(emergencies);
+
         emergencies.Should().BeEmpty();
     }
 
     [Test]
-    public void LoadUsersAsync_ShouldReturnEmptyCollection()
+    public async Task LoadUsersAsync_WhenRepositoryReturnsEmptyCollection_ShouldLeaveCollectionEmpty()
     {
-        // Arrange
         var users = new ObservableCollection<User>();
 
-        // Act
-        Task result = _service.LoadUsersAsync(users);
+        _userRepository.GetAllAsync()
+            .Returns(Task.FromResult<IReadOnlyList<User>>(Array.Empty<User>()));
 
-        // Assert
-        result.Should().NotBeNull();
+        await _service.LoadUsersAsync(users);
+
         users.Should().BeEmpty();
     }
 
     [Test]
-    public async Task LoadActiveEmergenciesAsync_ShouldCompleteSuccessfully()
+    public async Task LoadActiveEmergenciesAsync_WhenRepositoryReturnsNull_ShouldLeaveCollectionEmpty()
     {
-        // Arrange
         var emergencies = new ObservableCollection<Emergency>();
 
-        // Act & Assert
+        _emergencyRepository.GetActiveAsync()
+            .Returns(Task.FromResult<IReadOnlyList<Emergency>>(null!));
+
         Func<Task> action = () => _service.LoadActiveEmergenciesAsync(emergencies);
+
         await action.Should().NotThrowAsync();
+        emergencies.Should().BeEmpty();
     }
 
     [Test]
-    public async Task LoadUsersAsync_ShouldCompleteSuccessfully()
+    public async Task LoadUsersAsync_WhenRepositoryReturnsNull_ShouldLeaveCollectionEmpty()
     {
-        // Arrange
         var users = new ObservableCollection<User>();
 
-        // Act & Assert
+        _userRepository.GetAllAsync()
+            .Returns(Task.FromResult<IReadOnlyList<User>>(null!));
+
         Func<Task> action = () => _service.LoadUsersAsync(users);
+
         await action.Should().NotThrowAsync();
+        users.Should().BeEmpty();
     }
 
     [Test]
-    public async Task LoadActiveEmergenciesAsync_WithNullCollection_ShouldHandleGracefully()
+    public async Task LoadActiveEmergenciesAsync_WithNullCollection_ShouldReturnCleanly()
     {
-        // Act & Assert
         Func<Task> action = () => _service.LoadActiveEmergenciesAsync(null!);
+
         await action.Should().NotThrowAsync();
+        _emergencyRepository.ReceivedCalls().Should().BeEmpty();
     }
 
     [Test]
-    public async Task LoadUsersAsync_WithNullCollection_ShouldHandleGracefully()
+    public async Task LoadUsersAsync_WithNullCollection_ShouldReturnCleanly()
     {
-        // Act & Assert
         Func<Task> action = () => _service.LoadUsersAsync(null!);
+
         await action.Should().NotThrowAsync();
+        _userRepository.ReceivedCalls().Should().BeEmpty();
     }
 }

--- a/OtChaim.Application/Services/EmergencyDataService.cs
+++ b/OtChaim.Application/Services/EmergencyDataService.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Collections.ObjectModel;
 using OtChaim.Domain.EmergencyEvents;
 using OtChaim.Domain.Users;
-using System.Collections.ObjectModel;
 
 namespace OtChaim.Application.Services;
 
@@ -23,9 +24,15 @@ public class EmergencyDataService(IEmergencyRepository emergencyRepository, IUse
     /// <param name="emergencies">The collection to populate with active emergencies.</param>
     public async Task LoadActiveEmergenciesAsync(ObservableCollection<Emergency> emergencies)
     {
+        if (emergencies is null)
+        {
+            return;
+        }
+
         try
         {
-            IReadOnlyList<Emergency> allEmergencies = await _emergencyRepository.GetActiveAsync();
+            IReadOnlyList<Emergency> allEmergencies =
+                await _emergencyRepository.GetActiveAsync() ?? Array.Empty<Emergency>();
             emergencies.Clear();
             foreach (Emergency emergency in allEmergencies)
             {
@@ -44,9 +51,15 @@ public class EmergencyDataService(IEmergencyRepository emergencyRepository, IUse
     /// <param name="users">The collection to populate with users.</param>
     public async Task LoadUsersAsync(ObservableCollection<User> users)
     {
+        if (users is null)
+        {
+            return;
+        }
+
         try
         {
-            IReadOnlyList<User> allUsers = await _userRepository.GetAllAsync();
+            IReadOnlyList<User> allUsers =
+                await _userRepository.GetAllAsync() ?? Array.Empty<User>();
             users.Clear();
             foreach (User user in allUsers)
             {


### PR DESCRIPTION
## Summary
- short-circuit emergency and user loading when passed a null target collection
- normalize repository responses to default to empty lists before iteration
- extend emergency data service tests to cover null collections and empty or null repository results

## Testing
- `dotnet test OtChaim.Application.Tests/OtChaim.Application.Tests.csproj` *(fails: NU1301 retrieving Yaref92.Events because proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_68d0e895eb808326ab8cdf701c5277c7