### PR TITLE
Align emergency contact toggles with send flags

### DIFF
--- a/OtChaim.Application.Tests/OtChaim.Application.Tests.csproj
+++ b/OtChaim.Application.Tests/OtChaim.Application.Tests.csproj
@@ -8,6 +8,7 @@
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
     <Configurations>Debug;Release;NoGui</Configurations>
+    <DefineConstants>$(DefineConstants);UNIT_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
@@ -16,6 +17,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FluentAssertions" Version="8.5.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="NUnit" Version="3.14.0" />
@@ -30,6 +32,12 @@
   <ItemGroup>
     <ProjectReference Include="..\OtChaim.Application\OtChaim.Application.csproj" />
     <ProjectReference Include="..\OtChaim.Domain\OtChaim.Domain.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="..\OtChaim.Presentation.MAUI\ViewModels\Tool\EmergencyCreationViewModel.cs">
+      <Link>ViewModels\Tool\EmergencyCreationViewModel.cs</Link>
+    </Compile>
   </ItemGroup>
 
 </Project>

--- a/OtChaim.Application.Tests/ViewModels/EmergencyCreationViewModelTests.cs
+++ b/OtChaim.Application.Tests/ViewModels/EmergencyCreationViewModelTests.cs
@@ -1,0 +1,95 @@
+using System.Threading;
+using System.Threading.Tasks;
+using CommunityToolkit.Mvvm.Input;
+using FluentAssertions;
+using OtChaim.Application.Common;
+using OtChaim.Application.EmergencyEvents.Commands;
+using OtChaim.Presentation.MAUI.ViewModels.Tool;
+
+namespace OtChaim.Application.Tests.ViewModels;
+
+public class EmergencyCreationViewModelTests
+{
+    [Test]
+    public async Task CreateEmergencyCommand_WhenEmailDisabled_DoesNotSetEmailFlag()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+
+        viewModel.ToggleEmailCommand.Execute(null);
+
+        await viewModel.CreateEmergencyCommand.ExecuteAsync(null);
+
+        handler.LastCommand.Should().NotBeNull();
+        handler.LastCommand!.Attachments.Should().NotBeNull();
+        handler.LastCommand.Attachments!.SendEmail.Should().BeFalse();
+        handler.LastCommand.Attachments.SendSms.Should().BeTrue();
+        handler.LastCommand.Attachments.SendMessenger.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CreateEmergencyCommand_WhenSmsDisabled_DoesNotSetSmsFlag()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+
+        viewModel.ToggleSmsCommand.Execute(null);
+
+        await viewModel.CreateEmergencyCommand.ExecuteAsync(null);
+
+        handler.LastCommand.Should().NotBeNull();
+        handler.LastCommand!.Attachments.Should().NotBeNull();
+        handler.LastCommand.Attachments!.SendEmail.Should().BeTrue();
+        handler.LastCommand.Attachments.SendSms.Should().BeFalse();
+        handler.LastCommand.Attachments.SendMessenger.Should().BeFalse();
+    }
+
+    [Test]
+    public async Task CreateEmergencyCommand_WhenMessengerDisabled_DoesNotSetMessengerFlag()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+
+        viewModel.ToggleMessengerCommand.Execute(null); // enable messenger
+        viewModel.ToggleMessengerCommand.Execute(null); // disable messenger again
+
+        await viewModel.CreateEmergencyCommand.ExecuteAsync(null);
+
+        handler.LastCommand.Should().NotBeNull();
+        handler.LastCommand!.Attachments.Should().NotBeNull();
+        handler.LastCommand.Attachments!.SendEmail.Should().BeTrue();
+        handler.LastCommand.Attachments.SendSms.Should().BeTrue();
+        handler.LastCommand.Attachments.SendMessenger.Should().BeFalse();
+    }
+
+    [Test]
+    public void CancelCommand_ResetsContactPreferences()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+
+        viewModel.ToggleEmailCommand.Execute(null);
+        viewModel.ToggleSmsCommand.Execute(null);
+        viewModel.ToggleMessengerCommand.Execute(null);
+
+        viewModel.CancelCommand.Execute(null);
+
+        viewModel.IsEmailSelected.Should().BeTrue();
+        viewModel.SendEmail.Should().BeTrue();
+        viewModel.IsSmsSelected.Should().BeTrue();
+        viewModel.SendSms.Should().BeTrue();
+        viewModel.IsMessengerSelected.Should().BeFalse();
+        viewModel.SendMessenger.Should().BeFalse();
+    }
+
+    private sealed class RecordingStartEmergencyHandler : ICommandHandler<StartEmergency>
+    {
+        public StartEmergency? LastCommand { get; private set; }
+
+        public Task Handle(StartEmergency command, CancellationToken cancellationToken)
+        {
+            LastCommand = command;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/OtChaim.Presentation.MAUI/ViewModels/Tool/EmergencyCreationViewModel.cs
+++ b/OtChaim.Presentation.MAUI/ViewModels/Tool/EmergencyCreationViewModel.cs
@@ -121,7 +121,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// This preference is stored in the emergency attachments for processing.
     /// </remarks>
     [ObservableProperty]
-    private bool _sendMessenger = true;
+    private bool _sendMessenger = false;
 
     /// <summary>
     /// Gets or sets a value indicating whether personal information should be attached.
@@ -249,9 +249,12 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
         LocationDescription = string.Empty;
         Latitude = 0;
         Longitude = 0;
-        SendEmail = true;
-        SendSms = true;
-        SendMessenger = false;
+        IsEmailSelected = true;
+        SendEmail = IsEmailSelected;
+        IsSmsSelected = true;
+        SendSms = IsSmsSelected;
+        IsMessengerSelected = false;
+        SendMessenger = IsMessengerSelected;
         AttachPersonalInfo = true;
         AttachMedicalInfo = true;
         AttachGps = true;
@@ -259,9 +262,6 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
         AttachedDocumentPath = string.Empty;
         IsGroupSelected = true;
         IsSingleSelected = false;
-        IsEmailSelected = true;
-        IsSmsSelected = true;
-        IsMessengerSelected = false;
     }
 
     [RelayCommand]
@@ -306,6 +306,9 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// this command will remove it instead.
     /// </remarks>
     [RelayCommand]
+#if UNIT_TESTS
+    private Task TogglePictureAsync() => Task.CompletedTask;
+#else
     private async Task TogglePictureAsync()
     {
         try
@@ -328,6 +331,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
             System.Diagnostics.Debug.WriteLine($"Error picking photo: {ex.Message}");
         }
     }
+#endif
 
     /// <summary>
     /// Command to add or remove a document attachment to the emergency.
@@ -338,6 +342,9 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// this command will remove it instead.
     /// </remarks>
     [RelayCommand]
+#if UNIT_TESTS
+    private Task ToggleDocumentAsync() => Task.CompletedTask;
+#else
     private async Task ToggleDocumentAsync()
     {
         try
@@ -360,6 +367,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
             System.Diagnostics.Debug.WriteLine($"Error picking document: {ex.Message}");
         }
     }
+#endif
 
     /// <summary>
     /// Command to toggle the personal information attachment.
@@ -420,18 +428,21 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     private void ToggleEmail()
     {
         IsEmailSelected = !IsEmailSelected;
+        SendEmail = IsEmailSelected;
     }
 
     [RelayCommand]
     private void ToggleSms()
     {
         IsSmsSelected = !IsSmsSelected;
+        SendSms = IsSmsSelected;
     }
 
     [RelayCommand]
     private void ToggleMessenger()
     {
         IsMessengerSelected = !IsMessengerSelected;
+        SendMessenger = IsMessengerSelected;
     }
 
     [RelayCommand]
@@ -525,6 +536,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     [RelayCommand]
     private void Cancel()
     {
+        ResetCreateEmergencyFields();
         Cancelled?.Invoke(this, EventArgs.Empty);
     }
 }


### PR DESCRIPTION
## Summary
- update the emergency creation view model so toggling contact options also updates the Send* flags and reset/cancel keep them aligned
- guard the MAUI file picker commands for UNIT_TESTS builds so the view model can be compiled inside the test project
- include the view model source in the application test project and add coverage that verifies disabled contact methods stay off in generated attachments

## Testing
- dotnet test OtChaim.NoGUI.slnf *(fails: unable to reach nuget.org to restore packages)*

------
https://chatgpt.com/codex/tasks/task_e_68d1022d891483268d6055c3e41413da