### PR TITLE
Ensure emergency attachments update visual states

### DIFF
--- a/OtChaim.Application.Tests/ViewModels/EmergencyCreationViewModelTests.cs
+++ b/OtChaim.Application.Tests/ViewModels/EmergencyCreationViewModelTests.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.Input;
@@ -80,6 +81,106 @@ public class EmergencyCreationViewModelTests
         viewModel.SendSms.Should().BeTrue();
         viewModel.IsMessengerSelected.Should().BeFalse();
         viewModel.SendMessenger.Should().BeFalse();
+    }
+
+    [Test]
+    public void TogglePersonalInfoCommand_NotifiesVisualStateBindings()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+        var changedProperties = new List<string>();
+        viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName ?? string.Empty);
+
+        viewModel.TogglePersonalInfoCommand.Execute(null);
+
+        viewModel.IsPersonalInfoAttached.Should().BeFalse();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsPersonalInfoAttached));
+
+        changedProperties.Clear();
+        viewModel.TogglePersonalInfoCommand.Execute(null);
+
+        viewModel.IsPersonalInfoAttached.Should().BeTrue();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsPersonalInfoAttached));
+    }
+
+    [Test]
+    public void ToggleMedicalInfoCommand_NotifiesVisualStateBindings()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+        var changedProperties = new List<string>();
+        viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName ?? string.Empty);
+
+        viewModel.ToggleMedicalInfoCommand.Execute(null);
+
+        viewModel.IsMedicalInfoAttached.Should().BeFalse();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsMedicalInfoAttached));
+
+        changedProperties.Clear();
+        viewModel.ToggleMedicalInfoCommand.Execute(null);
+
+        viewModel.IsMedicalInfoAttached.Should().BeTrue();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsMedicalInfoAttached));
+    }
+
+    [Test]
+    public void ToggleGpsCommand_NotifiesVisualStateBindings()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+        var changedProperties = new List<string>();
+        viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName ?? string.Empty);
+
+        viewModel.ToggleGpsCommand.Execute(null);
+
+        viewModel.IsGpsAttached.Should().BeFalse();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsGpsAttached));
+
+        changedProperties.Clear();
+        viewModel.ToggleGpsCommand.Execute(null);
+
+        viewModel.IsGpsAttached.Should().BeTrue();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsGpsAttached));
+    }
+
+    [Test]
+    public void AttachedPicturePath_NotifiesVisualStateBindings()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+        var changedProperties = new List<string>();
+        viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName ?? string.Empty);
+
+        viewModel.AttachedPicturePath = "picture.jpg";
+
+        viewModel.IsPictureAttached.Should().BeTrue();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsPictureAttached));
+
+        changedProperties.Clear();
+        viewModel.AttachedPicturePath = string.Empty;
+
+        viewModel.IsPictureAttached.Should().BeFalse();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsPictureAttached));
+    }
+
+    [Test]
+    public void AttachedDocumentPath_NotifiesVisualStateBindings()
+    {
+        var handler = new RecordingStartEmergencyHandler();
+        var viewModel = new EmergencyCreationViewModel(handler);
+        var changedProperties = new List<string>();
+        viewModel.PropertyChanged += (_, e) => changedProperties.Add(e.PropertyName ?? string.Empty);
+
+        viewModel.AttachedDocumentPath = "document.pdf";
+
+        viewModel.IsDocumentAttached.Should().BeTrue();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsDocumentAttached));
+
+        changedProperties.Clear();
+        viewModel.AttachedDocumentPath = string.Empty;
+
+        viewModel.IsDocumentAttached.Should().BeFalse();
+        changedProperties.Should().Contain(nameof(EmergencyCreationViewModel.IsDocumentAttached));
     }
 
     private sealed class RecordingStartEmergencyHandler : ICommandHandler<StartEmergency>

--- a/OtChaim.Presentation.MAUI/ViewModels/Tool/EmergencyCreationViewModel.cs
+++ b/OtChaim.Presentation.MAUI/ViewModels/Tool/EmergencyCreationViewModel.cs
@@ -131,6 +131,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// to the emergency notification. This can be toggled on/off by the user.
     /// </remarks>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsPersonalInfoAttached))]
     private bool _attachPersonalInfo = true;
 
     /// <summary>
@@ -141,6 +142,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// to the emergency notification. This can be toggled on/off by the user.
     /// </remarks>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsMedicalInfoAttached))]
     private bool _attachMedicalInfo = true;
 
     /// <summary>
@@ -151,6 +153,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// to the emergency notification. This can be toggled on/off by the user.
     /// </remarks>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsGpsAttached))]
     private bool _attachGps = true;
 
     /// <summary>
@@ -161,6 +164,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// by the user to be attached to the emergency notification.
     /// </remarks>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsPictureAttached))]
     private string _attachedPicturePath = string.Empty;
 
     /// <summary>
@@ -171,6 +175,7 @@ public partial class EmergencyCreationViewModel : BaseEmergencyViewModel
     /// by the user to be attached to the emergency notification.
     /// </remarks>
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsDocumentAttached))]
     private string _attachedDocumentPath = string.Empty;
 
     /// <summary>


### PR DESCRIPTION
## Summary
- add NotifyPropertyChangedFor annotations so attachment toggles raise the derived visual state flags
- extend the emergency creation view model tests to assert PropertyChanged notifications for each attachment

## Testing
- dotnet test OtChaim.Application.Tests/OtChaim.Application.Tests.csproj *(fails: proxy 403 when restoring Yaref92.Events)*

------
https://chatgpt.com/codex/tasks/task_e_68d106302fe88326aea41f09d84a8ad8