### PR TITLE
Implement user profile management screen

### DIFF
--- a/OtChaim.Application.Tests/Services/UserProfileServiceTests.cs
+++ b/OtChaim.Application.Tests/Services/UserProfileServiceTests.cs
@@ -1,0 +1,64 @@
+using FluentAssertions;
+using NSubstitute;
+using OtChaim.Application.Services;
+using OtChaim.Domain.Users;
+
+namespace OtChaim.Application.Tests.Services;
+
+[TestFixture]
+public class UserProfileServiceTests
+{
+    private IUserRepository _userRepository = null!;
+    private UserProfileService _service = null!;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _userRepository = Substitute.For<IUserRepository>();
+        _service = new UserProfileService(_userRepository);
+    }
+
+    [Test]
+    public async Task GetOrCreatePrimaryUserAsync_ShouldReturnExistingUser()
+    {
+        // Arrange
+        User existing = new User("Existing User", "existing@example.com", "123");
+        _userRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns(new List<User> { existing });
+
+        // Act
+        User result = await _service.GetOrCreatePrimaryUserAsync();
+
+        // Assert
+        result.Should().Be(existing);
+        await _userRepository.DidNotReceive().AddAsync(Arg.Any<User>(), Arg.Any<CancellationToken>());
+    }
+
+    [Test]
+    public async Task GetOrCreatePrimaryUserAsync_ShouldCreateDefaultUser_WhenNoneExists()
+    {
+        // Arrange
+        _userRepository.GetAllAsync(Arg.Any<CancellationToken>()).Returns(new List<User>());
+
+        // Act
+        User result = await _service.GetOrCreatePrimaryUserAsync();
+
+        // Assert
+        await _userRepository.Received(1).AddAsync(result, Arg.Any<CancellationToken>());
+        result.FirstName.Should().Be("Finn");
+        result.LastName.Should().Be("Mond");
+        result.Email.Should().Be("Finn@moon.com");
+    }
+
+    [Test]
+    public async Task SaveAsync_ShouldPersistUsingRepository()
+    {
+        // Arrange
+        User user = new User("John Doe", "john@example.com", "123");
+
+        // Act
+        await _service.SaveAsync(user);
+
+        // Assert
+        await _userRepository.Received(1).SaveAsync(user, Arg.Any<CancellationToken>());
+    }
+}

--- a/OtChaim.Application/Services/UserProfileService.cs
+++ b/OtChaim.Application/Services/UserProfileService.cs
@@ -1,0 +1,49 @@
+using OtChaim.Domain.Common;
+using OtChaim.Domain.Users;
+using System.Linq;
+
+namespace OtChaim.Application.Services;
+
+/// <summary>
+/// Provides access to the user's personal profile information.
+/// </summary>
+public class UserProfileService(IUserRepository userRepository)
+{
+    private readonly IUserRepository _userRepository = userRepository;
+
+    /// <summary>
+    /// Retrieves the primary user profile, creating a default profile when none exists.
+    /// </summary>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public async Task<User> GetOrCreatePrimaryUserAsync(CancellationToken cancellationToken = default)
+    {
+        IReadOnlyList<User> users = await _userRepository.GetAllAsync(cancellationToken) ?? Array.Empty<User>();
+        User? existing = users.FirstOrDefault();
+        if (existing is not null)
+        {
+            return existing;
+        }
+
+        User defaultUser = new User("Finn Mond", "Finn@moon.com", "+71/182637263");
+        defaultUser.UpdatePersonalProfile(
+            "Finn",
+            "Mond",
+            new DateTime(1990, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            83,
+            "A",
+            "Mondstrasse 3, 71626 Bonn",
+            Location.Empty,
+            string.Empty);
+
+        await _userRepository.AddAsync(defaultUser, cancellationToken);
+        return defaultUser;
+    }
+
+    /// <summary>
+    /// Persists the provided user profile changes.
+    /// </summary>
+    /// <param name="user">The user to persist.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    public Task SaveAsync(User user, CancellationToken cancellationToken = default)
+        => _userRepository.SaveAsync(user, cancellationToken);
+}

--- a/OtChaim.Domain.Tests/Users/UserTests.cs
+++ b/OtChaim.Domain.Tests/Users/UserTests.cs
@@ -1,0 +1,65 @@
+using FluentAssertions;
+using OtChaim.Domain.Common;
+using OtChaim.Domain.Users;
+
+namespace OtChaim.Domain.Tests.Users;
+
+[TestFixture]
+public class UserTests
+{
+    [Test]
+    public void UpdatePersonalProfile_WithValidValues_ShouldUpdateUserState()
+    {
+        // Arrange
+        User user = new User("John Doe", "john@example.com", "123456789");
+        DateTime birthDate = new DateTime(1990, 5, 12, 0, 0, 0, DateTimeKind.Utc);
+        Location location = new Location(45.1234, -93.1234, "Home");
+
+        // Act
+        user.UpdatePersonalProfile("John", "Doe", birthDate, 82.3, "O-", "123 Main St", location, "profile.jpg");
+
+        // Assert
+        user.FirstName.Should().Be("John");
+        user.LastName.Should().Be("Doe");
+        user.Name.Should().Be("John Doe");
+        user.BirthDate.Should().Be(birthDate.Date);
+        user.WeightInKg.Should().Be(82.3);
+        user.BloodType.Should().Be("O-");
+        user.Address.Should().Be("123 Main St");
+        user.CurrentLocation.Latitude.Should().Be(location.Latitude);
+        user.CurrentLocation.Longitude.Should().Be(location.Longitude);
+        user.ProfilePicturePath.Should().Be("profile.jpg");
+    }
+
+    [Test]
+    public void UpdatePersonalProfile_WithEmptyFirstName_ShouldThrow()
+    {
+        User user = new User("Jane Doe", "jane@example.com", "123456789");
+
+        Action act = () => user.UpdatePersonalProfile(string.Empty, "Doe", DateTime.UtcNow, 70, "A+", "", Location.Empty, null);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void UpdatePersonalProfile_WithFutureBirthDate_ShouldThrow()
+    {
+        User user = new User("Jane Doe", "jane@example.com", "123456789");
+        DateTime futureBirthDate = DateTime.Today.AddDays(1);
+
+        Action act = () => user.UpdatePersonalProfile("Jane", "Doe", futureBirthDate, 70, "A+", "", Location.Empty, null);
+
+        act.Should().Throw<ArgumentException>();
+    }
+
+    [Test]
+    public void UpdateContactInformation_ShouldUpdateEmailAndPhone()
+    {
+        User user = new User("Jane Doe", "jane@example.com", "123456789");
+
+        user.UpdateContactInformation("updated@example.com", "987654321");
+
+        user.Email.Should().Be("updated@example.com");
+        user.PhoneNumber.Should().Be("987654321");
+    }
+}

--- a/OtChaim.Domain/Users/User.cs
+++ b/OtChaim.Domain/Users/User.cs
@@ -1,6 +1,7 @@
 using OtChaim.Domain.Common;
 using OtChaim.Domain.Notifications;
 using OtChaim.Domain.Users.Events;
+using System.Linq;
 
 namespace OtChaim.Domain.Users;
 
@@ -14,6 +15,14 @@ public class User : Entity
     /// </summary>
     public string Name { get; private set; } = string.Empty;
     /// <summary>
+    /// Gets the user's first name.
+    /// </summary>
+    public string FirstName { get; private set; } = string.Empty;
+    /// <summary>
+    /// Gets the user's last name.
+    /// </summary>
+    public string LastName { get; private set; } = string.Empty;
+    /// <summary>
     /// Gets the user's email address.
     /// </summary>
     public string Email { get; private set; } = string.Empty;
@@ -25,6 +34,30 @@ public class User : Entity
     /// Gets a value indicating whether the user is active.
     /// </summary>
     public bool IsActive { get; private set; }
+    /// <summary>
+    /// Gets the user's birth date if provided.
+    /// </summary>
+    public DateTime? BirthDate { get; private set; }
+    /// <summary>
+    /// Gets the user's weight in kilograms if provided.
+    /// </summary>
+    public double? WeightInKg { get; private set; }
+    /// <summary>
+    /// Gets the user's blood type.
+    /// </summary>
+    public string BloodType { get; private set; } = string.Empty;
+    /// <summary>
+    /// Gets the user's home address.
+    /// </summary>
+    public string Address { get; private set; } = string.Empty;
+    /// <summary>
+    /// Gets the user's current location.
+    /// </summary>
+    public Location CurrentLocation { get; private set; } = Location.Empty;
+    /// <summary>
+    /// Gets the path to the user's profile picture if one is set.
+    /// </summary>
+    public string ProfilePicturePath { get; private set; } = string.Empty;
     private readonly List<Guid> _subscriberIds = [];
     /// <summary>
     /// Gets the list of subscriber IDs.
@@ -63,10 +96,82 @@ public class User : Entity
             throw new ArgumentException("Phone number cannot be empty", nameof(phoneNumber));
 
         Id = Guid.NewGuid();
-        Name = name;
+        SetNameFromFullName(name);
         Email = email;
         PhoneNumber = phoneNumber;
         IsActive = true;
+    }
+
+    /// <summary>
+    /// Updates the core personal profile information for the user.
+    /// </summary>
+    /// <param name="firstName">The first name.</param>
+    /// <param name="lastName">The last name.</param>
+    /// <param name="birthDate">The optional birth date.</param>
+    /// <param name="weightInKg">The optional weight in kilograms.</param>
+    /// <param name="bloodType">The blood type.</param>
+    /// <param name="address">The home address.</param>
+    /// <param name="currentLocation">The current GPS location.</param>
+    /// <param name="profilePicturePath">The path to the profile picture.</param>
+    public void UpdatePersonalProfile(
+        string firstName,
+        string lastName,
+        DateTime? birthDate,
+        double? weightInKg,
+        string bloodType,
+        string address,
+        Location? currentLocation,
+        string? profilePicturePath)
+    {
+        if (string.IsNullOrWhiteSpace(firstName))
+        {
+            throw new ArgumentException("First name cannot be empty", nameof(firstName));
+        }
+
+        if (string.IsNullOrWhiteSpace(lastName))
+        {
+            throw new ArgumentException("Last name cannot be empty", nameof(lastName));
+        }
+
+        if (birthDate.HasValue && birthDate.Value.Date > DateTime.UtcNow.Date)
+        {
+            throw new ArgumentException("Birth date cannot be in the future", nameof(birthDate));
+        }
+
+        if (weightInKg.HasValue && weightInKg.Value <= 0)
+        {
+            throw new ArgumentException("Weight must be greater than zero", nameof(weightInKg));
+        }
+
+        UpdateNameFromParts(firstName, lastName);
+
+        BirthDate = birthDate?.Date;
+        WeightInKg = weightInKg;
+        BloodType = (bloodType ?? string.Empty).Trim();
+        Address = (address ?? string.Empty).Trim();
+        CurrentLocation = (currentLocation ?? Location.Empty).Clone();
+        ProfilePicturePath = profilePicturePath?.Trim() ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Updates the user's contact information.
+    /// </summary>
+    /// <param name="email">The email address.</param>
+    /// <param name="phoneNumber">The phone number.</param>
+    public void UpdateContactInformation(string email, string phoneNumber)
+    {
+        if (string.IsNullOrWhiteSpace(email))
+        {
+            throw new ArgumentException("Email cannot be empty", nameof(email));
+        }
+
+        if (string.IsNullOrWhiteSpace(phoneNumber))
+        {
+            throw new ArgumentException("Phone number cannot be empty", nameof(phoneNumber));
+        }
+
+        Email = email;
+        PhoneNumber = phoneNumber;
     }
 
     /// <summary>
@@ -142,5 +247,34 @@ public class User : Entity
     {
         Subscription? subscription = _subscriptions.FirstOrDefault(s => s.SubscriberId == subscriptionEvent.SubscriberId && s.SubscribedToId == subscriptionEvent.SubscribedToId);
         subscription?.Reject();
+    }
+
+    private void SetNameFromFullName(string name)
+    {
+        string trimmedName = name.Trim();
+        Name = trimmedName;
+
+        if (string.IsNullOrWhiteSpace(trimmedName))
+        {
+            FirstName = string.Empty;
+            LastName = string.Empty;
+            return;
+        }
+
+        string[] parts = trimmedName
+            .Split(' ', 2, StringSplitOptions.RemoveEmptyEntries);
+        FirstName = parts.Length > 0 ? parts[0] : trimmedName;
+        LastName = parts.Length > 1 ? parts[1] : string.Empty;
+    }
+
+    private void UpdateNameFromParts(string firstName, string lastName)
+    {
+        FirstName = firstName.Trim();
+        LastName = lastName.Trim();
+
+        string combinedName = string.Join(" ", new[] { FirstName, LastName }
+            .Where(part => !string.IsNullOrWhiteSpace(part)));
+
+        Name = combinedName;
     }
 }

--- a/OtChaim.Persistence.Tests/UserRepositoryTests.cs
+++ b/OtChaim.Persistence.Tests/UserRepositoryTests.cs
@@ -1,5 +1,6 @@
 using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
+using OtChaim.Domain.Common;
 using OtChaim.Domain.Users;
 
 namespace OtChaim.Persistence.Tests;
@@ -31,6 +32,15 @@ public class UserRepositoryTests
     {
         // Arrange
         User user = new User("test", "test@example.com", "00000000");
+        user.UpdatePersonalProfile(
+            "test",
+            "user",
+            new DateTime(1990, 1, 1, 0, 0, 0, DateTimeKind.Utc),
+            72.5,
+            "O+",
+            "123 Main Street",
+            new Location(32.0853, 34.7818, "Home"),
+            "profile.jpg");
 
         // Act
         await _repository.AddAsync(user);
@@ -39,6 +49,14 @@ public class UserRepositoryTests
         // Assert
         loaded.Should().NotBeNull();
         loaded.Id.Should().Be(user.Id);
+        loaded.FirstName.Should().Be("test");
+        loaded.LastName.Should().Be("user");
+        loaded.BloodType.Should().Be("O+");
+        loaded.WeightInKg.Should().Be(72.5);
+        loaded.Address.Should().Be("123 Main Street");
+        loaded.ProfilePicturePath.Should().Be("profile.jpg");
+        loaded.CurrentLocation.Latitude.Should().BeApproximately(32.0853, 0.0001);
+        loaded.CurrentLocation.Longitude.Should().BeApproximately(34.7818, 0.0001);
     }
 
     [Test]

--- a/OtChaim.Persistence/OtChaimDbContext.cs
+++ b/OtChaim.Persistence/OtChaimDbContext.cs
@@ -60,6 +60,7 @@ public class OtChaimDbContext(DbContextOptions<OtChaimDbContext> options) : DbCo
         modelBuilder.Entity<User>(builder =>
         {
             builder.HasKey(u => u.Id);
+            builder.OwnsOne(u => u.CurrentLocation, ConfigureLocation);
             builder.OwnsMany(u => u.NotificationChannels, nc =>
             {
                 nc.Property(n => n.ChannelType);

--- a/OtChaim.Presentation.MAUI/MauiProgram.cs
+++ b/OtChaim.Presentation.MAUI/MauiProgram.cs
@@ -35,6 +35,7 @@ public static class MauiProgram
 
         // Register application serviceProvider
         builder.Services.AddSingleton<EmergencyDataService>();
+        builder.Services.AddSingleton<UserProfileService>();
 
         // Register view models
         builder.Services.AddTransient<EmergencyDashboardViewModel>();

--- a/OtChaim.Presentation.MAUI/Pages/Settings/UserInfoPage.xaml
+++ b/OtChaim.Presentation.MAUI/Pages/Settings/UserInfoPage.xaml
@@ -8,93 +8,146 @@
 
     <ScrollView>
         <VerticalStackLayout Padding="20" Spacing="20">
-            
-            <!-- Profile Picture Section -->
+
+            <Label Text="User Information"
+                   FontFamily="OpenSansSemibold"
+                   FontSize="24"
+                   TextColor="{StaticResource White}" />
+
             <Frame BackgroundColor="{StaticResource White}" CornerRadius="16" Padding="16">
                 <VerticalStackLayout Spacing="12" HorizontalOptions="Center">
-                    <Image Source="profile_picture.png" HeightRequest="100" WidthRequest="100" 
-                           HorizontalOptions="Center" />
-                    <Label Text="choose pic" FontSize="16" TextColor="{StaticResource Gray600}" 
-                           HorizontalOptions="Center" />
+                    <Border HeightRequest="120" WidthRequest="120" StrokeThickness="0">
+                        <Border.StrokeShape>
+                            <RoundRectangle CornerRadius="60" />
+                        </Border.StrokeShape>
+                        <Image Source="{Binding ProfileImage}"
+                               Aspect="AspectFill" />
+                    </Border>
+
+                    <HorizontalStackLayout Spacing="12">
+                        <Button Text="Choose Pic"
+                                Command="{Binding ChooseProfilePictureCommand}"
+                                Style="{StaticResource MessageButton}" />
+                        <Button Text="Remove"
+                                Command="{Binding RemoveProfilePictureCommand}"
+                                Style="{StaticResource MessageButton}"
+                                IsVisible="{Binding HasProfilePicture}" />
+                    </HorizontalStackLayout>
+
+                    <ActivityIndicator IsRunning="{Binding IsBusy}"
+                                        IsVisible="{Binding IsBusy}" />
                 </VerticalStackLayout>
             </Frame>
 
-            <!-- Personal Information Form -->
             <Frame BackgroundColor="{StaticResource White}" CornerRadius="16" Padding="16">
                 <VerticalStackLayout Spacing="16">
-                    <Label Text="Personal Information" FontSize="18" FontFamily="OpenSansSemibold" />
-                    
-                    <!-- First Name -->
-                    <VerticalStackLayout Spacing="4">
-                        <Label Text="First name:" FontSize="16" />
-                        <Entry Text="{Binding FirstName}" Placeholder="Enter first name" FontSize="18" />
+                    <Label Text="Personal Information"
+                           FontSize="18"
+                           FontFamily="OpenSansSemibold" />
+
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="First Name"
+                               FontSize="16" />
+                        <Entry Text="{Binding FirstName}"
+                               Placeholder="Enter first name"
+                               FontSize="18" />
                     </VerticalStackLayout>
-                    
-                    <!-- Last Name -->
-                    <VerticalStackLayout Spacing="4">
-                        <Label Text="Last Name:" FontSize="16" />
-                        <Entry Text="{Binding LastName}" Placeholder="Enter last name" FontSize="18" />
+
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Last Name"
+                               FontSize="16" />
+                        <Entry Text="{Binding LastName}"
+                               Placeholder="Enter last name"
+                               FontSize="18" />
                     </VerticalStackLayout>
-                    
-                    <!-- Birthday -->
-                    <VerticalStackLayout Spacing="4">
-                        <Label Text="Birthday:" FontSize="16" />
-                        <DatePicker Date="{Binding Birthday}" FontSize="18" />
+
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Birthday"
+                               FontSize="16" />
+                        <DatePicker Date="{Binding Birthday}"
+                                    FontSize="18" />
                     </VerticalStackLayout>
-                    
-                    <!-- Weight -->
-                    <VerticalStackLayout Spacing="4">
-                        <Label Text="Weight:" FontSize="16" />
-                        <Entry Text="{Binding Weight}" Placeholder="Enter weight" FontSize="18" Keyboard="Numeric" />
+
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Weight (kg)"
+                               FontSize="16" />
+                        <Entry Text="{Binding Weight}"
+                               Placeholder="Enter weight"
+                               FontSize="18"
+                               Keyboard="Numeric" />
                     </VerticalStackLayout>
-                    
-                    <!-- Blood Type -->
-                    <VerticalStackLayout Spacing="4">
-                        <Label Text="Bloodtype:" FontSize="16" />
-                        <Picker Title="Select blood type" SelectedItem="{Binding SelectedBloodType}" 
-                                ItemsSource="{Binding BloodTypes}" FontSize="18" />
+
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="Blood Type"
+                               FontSize="16" />
+                        <Picker Title="Select blood type"
+                                SelectedItem="{Binding SelectedBloodType}"
+                                ItemsSource="{Binding BloodTypes}"
+                                FontSize="18" />
                     </VerticalStackLayout>
                 </VerticalStackLayout>
             </Frame>
 
-            <!-- Contact Information Display -->
             <Frame BackgroundColor="{StaticResource White}" CornerRadius="16" Padding="16">
                 <VerticalStackLayout Spacing="16">
-                    <Label Text="Contact Information" FontSize="18" FontFamily="OpenSansSemibold" />
-                    
-                    <!-- Address -->
+                    <Label Text="Contact Information"
+                           FontSize="18"
+                           FontFamily="OpenSansSemibold" />
+
                     <VerticalStackLayout Spacing="4">
-                        <Label Text="Address:" FontSize="16" />
-                        <Label Text="{Binding Address}" FontSize="18" TextColor="{StaticResource Gray600}" />
+                        <Label Text="Address"
+                               FontSize="16" />
+                        <Label Text="{Binding Address}"
+                               FontSize="18"
+                               TextColor="{StaticResource Gray600}" />
                     </VerticalStackLayout>
-                    
-                    <!-- Current Location -->
+
                     <VerticalStackLayout Spacing="4">
-                        <Label Text="Current Location:" FontSize="16" />
-                        <Label Text="{Binding CurrentLocation}" FontSize="18" TextColor="{StaticResource Gray600}" />
+                        <Label Text="Current Location"
+                               FontSize="16" />
+                        <Grid ColumnDefinitions="*,Auto" ColumnSpacing="8">
+                            <Label Text="{Binding CurrentLocation}"
+                                   FontSize="18"
+                                   TextColor="{StaticResource Gray600}"
+                                   Grid.Column="0" />
+                            <Button Text="Update GPS"
+                                    Command="{Binding RefreshLocationCommand}"
+                                    Style="{StaticResource MessageButton}"
+                                    Grid.Column="1" />
+                        </Grid>
                     </VerticalStackLayout>
-                    
-                    <!-- Phone -->
+
                     <VerticalStackLayout Spacing="4">
-                        <Label Text="Phone:" FontSize="16" />
-                        <Label Text="{Binding Phone}" FontSize="18" TextColor="{StaticResource Gray600}" />
+                        <Label Text="Phone"
+                               FontSize="16" />
+                        <Label Text="{Binding Phone}"
+                               FontSize="18"
+                               TextColor="{StaticResource Gray600}" />
                     </VerticalStackLayout>
-                    
-                    <!-- Email -->
+
                     <VerticalStackLayout Spacing="4">
-                        <Label Text="Mail:" FontSize="16" />
-                        <Label Text="{Binding Email}" FontSize="18" TextColor="{StaticResource Gray600}" />
+                        <Label Text="Email"
+                               FontSize="16" />
+                        <Label Text="{Binding Email}"
+                               FontSize="18"
+                               TextColor="{StaticResource Gray600}" />
                     </VerticalStackLayout>
                 </VerticalStackLayout>
             </Frame>
 
-            <!-- Management Buttons -->
+            <Label Text="{Binding StatusMessage}"
+                   TextColor="{Binding StatusMessageColor}"
+                   FontSize="16"
+                   IsVisible="{Binding HasStatusMessage}" />
+
             <Grid ColumnDefinitions="*,*" ColumnSpacing="10">
-                <Button Grid.Column="0" Text="+" 
-                        Command="{Binding AddInfoCommand}"
+                <Button Grid.Column="0"
+                        Text="+"
+                        Command="{Binding SaveProfileCommand}"
                         Style="{StaticResource MessageButton}" />
-                <Button Grid.Column="1" Text="-" 
-                        Command="{Binding RemoveInfoCommand}"
+                <Button Grid.Column="1"
+                        Text="-"
+                        Command="{Binding ResetProfileCommand}"
                         Style="{StaticResource MessageButton}" />
             </Grid>
 

--- a/OtChaim.Presentation.MAUI/Pages/Settings/UserInfoPage.xaml.cs
+++ b/OtChaim.Presentation.MAUI/Pages/Settings/UserInfoPage.xaml.cs
@@ -4,9 +4,27 @@ namespace OtChaim.Presentation.MAUI.Pages.Settings;
 
 public partial class UserInfoPage : ContentView
 {
+    private bool _isLoaded;
+
     public UserInfoPage(UserInfoViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
+        Loaded += OnLoaded;
+    }
+
+    private async void OnLoaded(object? sender, EventArgs e)
+    {
+        if (_isLoaded)
+        {
+            return;
+        }
+
+        _isLoaded = true;
+
+        if (BindingContext is UserInfoViewModel viewModel)
+        {
+            await viewModel.InitializeAsync();
+        }
     }
 }

--- a/OtChaim.Presentation.MAUI/ViewModels/Settings/UserInfoViewModel.cs
+++ b/OtChaim.Presentation.MAUI/ViewModels/Settings/UserInfoViewModel.cs
@@ -1,58 +1,437 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using System.Collections.ObjectModel;
+using Microsoft.Maui.Controls;
+using Microsoft.Maui.Graphics;
+using OtChaim.Application.Services;
+using OtChaim.Domain.Common;
+using OtChaim.Domain.Users;
+
+#if !UNIT_TESTS
+using Microsoft.Maui.ApplicationModel;
+using Microsoft.Maui.Devices.Sensors;
+using Microsoft.Maui.Storage;
+#endif
 
 namespace OtChaim.Presentation.MAUI.ViewModels.Settings;
 
+/// <summary>
+/// View model backing the settings tab user information page.
+/// </summary>
 public partial class UserInfoViewModel : ObservableObject
 {
-    [ObservableProperty]
-    private string _firstName = "Finn";
+    private readonly UserProfileService _userProfileService;
+    private User? _user;
+    private Location _activeLocation = Location.Empty;
+    private bool _isInitialized;
+    private DateTime? _initialBirthDate;
+    private double? _initialWeight;
+    private string _initialFirstName = string.Empty;
+    private string _initialLastName = string.Empty;
+    private string _initialBloodType = string.Empty;
+    private string _initialAddress = string.Empty;
+    private Location _initialLocation = Location.Empty;
+    private string _initialProfilePicturePath = string.Empty;
+
+    /// <summary>
+    /// Available blood type options.
+    /// </summary>
+    public ObservableCollection<string> BloodTypes { get; } = new(
+    [
+        "A",
+        "A+",
+        "A-",
+        "B",
+        "B+",
+        "B-",
+        "AB",
+        "AB+",
+        "AB-",
+        "O",
+        "O+",
+        "O-"
+    ]);
 
     [ObservableProperty]
-    private string _lastName = "Mond";
+    [NotifyPropertyChangedFor(nameof(ProfileImage))]
+    [NotifyPropertyChangedFor(nameof(HasProfilePicture))]
+    private string _profilePicturePath = string.Empty;
+
+    /// <summary>
+    /// Gets the image source for the profile picture.
+    /// </summary>
+    public ImageSource ProfileImage => string.IsNullOrWhiteSpace(ProfilePicturePath)
+        ? ImageSource.FromFile("profile_picture.png")
+        : ImageSource.FromFile(ProfilePicturePath);
+
+    /// <summary>
+    /// Gets a value indicating whether a profile picture has been chosen.
+    /// </summary>
+    public bool HasProfilePicture => !string.IsNullOrWhiteSpace(ProfilePicturePath);
 
     [ObservableProperty]
-    private DateTime _birthday = new(1955, 1, 21, 0, 0, 0, DateTimeKind.Utc);
+    private string _firstName = string.Empty;
 
     [ObservableProperty]
-    private string _weight = "83 Kg";
+    private string _lastName = string.Empty;
 
     [ObservableProperty]
-    private string _selectedBloodType = "A";
+    private DateTime _birthday = DateTime.Today;
 
     [ObservableProperty]
-    private string _address = "Mondstrasse 3, 71626 Bonn";
+    private string _weight = string.Empty;
+
+    [ObservableProperty]
+    private string _selectedBloodType = string.Empty;
+
+    [ObservableProperty]
+    private string _address = string.Empty;
 
     [ObservableProperty]
     private string _currentLocation = "Get GPS coordinates";
 
     [ObservableProperty]
-    private string _phone = "+71/182637263";
+    private string _phone = string.Empty;
 
     [ObservableProperty]
-    private string _email = "Finn@moon.com";
+    private string _email = string.Empty;
 
-    public ObservableCollection<string> BloodTypes { get; } =
-    [
-        "A", "B", "AB", "O"
-    ];
+    [ObservableProperty]
+    private bool _isBusy;
 
-    public UserInfoViewModel()
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasStatusMessage))]
+    [NotifyPropertyChangedFor(nameof(StatusMessageColor))]
+    private string _statusMessage = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusMessageColor))]
+    private bool _isError;
+
+    /// <summary>
+    /// Gets a value indicating whether there is a status message to display.
+    /// </summary>
+    public bool HasStatusMessage => !string.IsNullOrWhiteSpace(StatusMessage);
+
+    /// <summary>
+    /// Gets the color for the status message.
+    /// </summary>
+    public Color StatusMessageColor => IsError ? Colors.Red : Colors.Green;
+
+    public UserInfoViewModel(UserProfileService userProfileService)
     {
+        _userProfileService = userProfileService;
+    }
+
+    /// <summary>
+    /// Initializes the view model by loading the current profile.
+    /// </summary>
+    public async Task InitializeAsync()
+    {
+        if (_isInitialized)
+        {
+            return;
+        }
+
+        _isInitialized = true;
+        await LoadAsync();
     }
 
     [RelayCommand]
-    private void AddInfo()
+    private async Task SaveProfileAsync()
     {
-        // TODO: Implement add info functionality
-        System.Diagnostics.Debug.WriteLine("Add Info");
+        if (_user is null)
+        {
+            SetStatus("No user profile loaded.", true);
+            return;
+        }
+
+        if (!TryValidate(out double? weightValue, out string normalizedBloodType))
+        {
+            return;
+        }
+
+        try
+        {
+            IsBusy = true;
+            DateTime selectedBirthday = DateTime.SpecifyKind(Birthday.Date, DateTimeKind.Utc);
+
+            SelectedBloodType = EnsureBloodType(normalizedBloodType);
+
+            _user.UpdatePersonalProfile(
+                FirstName,
+                LastName,
+                selectedBirthday,
+                weightValue,
+                normalizedBloodType,
+                Address,
+                _activeLocation,
+                ProfilePicturePath);
+
+            await _userProfileService.SaveAsync(_user);
+
+            CacheSnapshot();
+            SetStatus("Profile saved successfully.", false);
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Failed to save profile: {ex.Message}", true);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
     }
 
     [RelayCommand]
-    private void RemoveInfo()
+    private void ResetProfile()
     {
-        // TODO: Implement remove info functionality
-        System.Diagnostics.Debug.WriteLine("Remove Info");
+        if (_user is null)
+        {
+            return;
+        }
+
+        ProfilePicturePath = _initialProfilePicturePath;
+        FirstName = _initialFirstName;
+        LastName = _initialLastName;
+        Birthday = (_initialBirthDate ?? DateTime.Today).Date;
+        Weight = FormatWeight(_initialWeight);
+        SelectedBloodType = EnsureBloodType(_initialBloodType);
+        Address = _initialAddress;
+        _activeLocation = _initialLocation.Clone();
+        CurrentLocation = FormatLocation(_activeLocation);
+        Phone = _user.PhoneNumber;
+        Email = _user.Email;
+        ClearStatus();
+    }
+
+    [RelayCommand]
+#if UNIT_TESTS
+    private Task ChooseProfilePictureAsync() => Task.CompletedTask;
+#else
+    private async Task ChooseProfilePictureAsync()
+    {
+        try
+        {
+            FileResult? photo = await MediaPicker.PickPhotoAsync();
+            if (photo is not null)
+            {
+                ProfilePicturePath = photo.FullPath;
+                SetStatus("Profile picture updated.", false);
+            }
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Unable to select photo: {ex.Message}", true);
+        }
+
+        return;
+    }
+#endif
+
+    [RelayCommand]
+    private void RemoveProfilePicture()
+    {
+        ProfilePicturePath = string.Empty;
+    }
+
+    [RelayCommand]
+#if UNIT_TESTS
+    private Task RefreshLocationAsync() => Task.CompletedTask;
+#else
+    private async Task RefreshLocationAsync()
+    {
+        try
+        {
+            IsBusy = true;
+            GeolocationRequest request = new(GeolocationAccuracy.Medium, TimeSpan.FromSeconds(10));
+            Microsoft.Maui.Devices.Sensors.Location? location = await Geolocation.Default.GetLocationAsync(request);
+
+            if (location is null)
+            {
+                SetStatus("Unable to determine location.", true);
+                return;
+            }
+
+            _activeLocation = new Location(location.Latitude, location.Longitude, Address);
+            CurrentLocation = FormatLocation(_activeLocation);
+            SetStatus("Location updated.", false);
+        }
+        catch (FeatureNotSupportedException ex)
+        {
+            SetStatus($"GPS not supported: {ex.Message}", true);
+        }
+        catch (FeatureNotEnabledException ex)
+        {
+            SetStatus($"GPS is disabled: {ex.Message}", true);
+        }
+        catch (PermissionException ex)
+        {
+            SetStatus($"GPS permission denied: {ex.Message}", true);
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Failed to retrieve location: {ex.Message}", true);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+#endif
+
+    private async Task LoadAsync()
+    {
+        try
+        {
+            IsBusy = true;
+            _user = await _userProfileService.GetOrCreatePrimaryUserAsync();
+            ApplyUser(_user);
+            ClearStatus();
+        }
+        catch (Exception ex)
+        {
+            SetStatus($"Failed to load profile: {ex.Message}", true);
+        }
+        finally
+        {
+            IsBusy = false;
+        }
+    }
+
+    private void ApplyUser(User user)
+    {
+        _initialFirstName = string.IsNullOrWhiteSpace(user.FirstName) ? user.Name : user.FirstName;
+        _initialLastName = user.LastName;
+        _initialBirthDate = user.BirthDate;
+        _initialWeight = user.WeightInKg;
+        _initialBloodType = user.BloodType;
+        _initialAddress = user.Address;
+        _initialLocation = user.CurrentLocation.Clone();
+        _initialProfilePicturePath = user.ProfilePicturePath;
+
+        ProfilePicturePath = _initialProfilePicturePath;
+        FirstName = _initialFirstName;
+        LastName = _initialLastName;
+        Birthday = (_initialBirthDate ?? DateTime.Today).Date;
+        Weight = FormatWeight(_initialWeight);
+        SelectedBloodType = EnsureBloodType(_initialBloodType);
+        Address = _initialAddress;
+        _activeLocation = _initialLocation.Clone();
+        CurrentLocation = FormatLocation(_activeLocation);
+        Phone = user.PhoneNumber;
+        Email = user.Email;
+    }
+
+    private void CacheSnapshot()
+    {
+        if (_user is null)
+        {
+            return;
+        }
+
+        _initialFirstName = _user.FirstName;
+        _initialLastName = _user.LastName;
+        _initialBirthDate = _user.BirthDate;
+        _initialWeight = _user.WeightInKg;
+        _initialBloodType = _user.BloodType;
+        _initialAddress = _user.Address;
+        _initialLocation = _user.CurrentLocation.Clone();
+        _initialProfilePicturePath = _user.ProfilePicturePath;
+    }
+
+    private bool TryValidate(out double? weightValue, out string normalizedBloodType)
+    {
+        List<string> errors = [];
+        weightValue = null;
+        normalizedBloodType = string.Empty;
+
+        if (string.IsNullOrWhiteSpace(FirstName))
+        {
+            errors.Add("First name is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(LastName))
+        {
+            errors.Add("Last name is required.");
+        }
+
+        if (Birthday.Date > DateTime.Today)
+        {
+            errors.Add("Birthday cannot be in the future.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(Weight))
+        {
+            if (!double.TryParse(Weight, NumberStyles.Float, CultureInfo.CurrentCulture, out double parsedWeight) || parsedWeight <= 0)
+            {
+                errors.Add("Weight must be a positive number.");
+            }
+            else
+            {
+                weightValue = parsedWeight;
+            }
+        }
+
+        string? trimmedBloodType = SelectedBloodType?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedBloodType))
+        {
+            errors.Add("Blood type must be selected.");
+        }
+        else
+        {
+            normalizedBloodType = trimmedBloodType.ToUpperInvariant();
+        }
+
+        if (errors.Count > 0)
+        {
+            SetStatus(string.Join(Environment.NewLine, errors), true);
+            return false;
+        }
+
+        return true;
+    }
+
+    private static string FormatWeight(double? weight)
+        => weight.HasValue
+            ? weight.Value.ToString("0.##", CultureInfo.CurrentCulture)
+            : string.Empty;
+
+    private string EnsureBloodType(string value)
+    {
+        string normalized = string.IsNullOrWhiteSpace(value)
+            ? BloodTypes.First()
+            : value.Trim().ToUpperInvariant();
+
+        if (!BloodTypes.Contains(normalized))
+        {
+            BloodTypes.Add(normalized);
+        }
+
+        return normalized;
+    }
+
+    private static string FormatLocation(Location location)
+    {
+        bool hasLocation = !(Math.Abs(location.Latitude + 1) < 0.000001 && Math.Abs(location.Longitude + 1) < 0.000001)
+            && location.Latitude is >= -90 and <= 90
+            && location.Longitude is >= -180 and <= 180;
+
+        return hasLocation
+            ? string.Create(CultureInfo.InvariantCulture, $"{location.Latitude:F5}, {location.Longitude:F5}")
+            : "Get GPS coordinates";
+    }
+
+    private void SetStatus(string message, bool isError)
+    {
+        StatusMessage = message;
+        IsError = isError;
+    }
+
+    private void ClearStatus()
+    {
+        StatusMessage = string.Empty;
+        IsError = false;
     }
 }


### PR DESCRIPTION
## Summary
- extend the domain `User` aggregate with personal profile data, add a profile service, and cover the new logic with unit tests
- rebuild the Settings > User Information screen to load, validate, and persist profile details with picture picking and GPS updates
- register the profile service in MAUI DI and update persistence tests to verify the additional fields are stored

## Testing
- `dotnet test` *(fails: nuget.org unreachable in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d03aa23bb8832687294ede05938154