### PR TITLE
Harden Android manifest permissions and camera flow

### DIFF
--- a/OtChaim.Presentation.MAUI/Platforms/Android/AndroidManifest.xml
+++ b/OtChaim.Presentation.MAUI/Platforms/Android/AndroidManifest.xml
@@ -1,13 +1,17 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1">
-	<application android:allowBackup="true" android:icon="@mipmap/appicon" android:supportsRtl="true"></application>
-	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-	<uses-permission android:name="android.permission.INTERNET" />
-	<!-- GPS Location permissions for User Information screen -->
-	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-	<!-- Camera and storage permissions for profile picture upload -->
-	<uses-permission android:name="android.permission.CAMERA" />
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
-	<uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <application
+        android:allowBackup="false"
+        android:icon="@mipmap/appicon"
+        android:supportsRtl="true"
+        android:usesCleartextTraffic="false" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+    <!-- GPS Location permissions for User Information screen -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Camera and storage permissions for profile picture upload -->
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
 </manifest>

--- a/OtChaim.Presentation.MAUI/ViewModels/Settings/UserInfoViewModel.cs
+++ b/OtChaim.Presentation.MAUI/ViewModels/Settings/UserInfoViewModel.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -218,12 +219,72 @@ public partial class UserInfoViewModel : ObservableObject
     {
         try
         {
-            FileResult? photo = await MediaPicker.PickPhotoAsync();
+            const string takePhotoOption = "Take Photo";
+            const string chooseFromGalleryOption = "Choose from Gallery";
+            const string cancelOption = "Cancel";
+
+            Page? currentPage = Shell.Current?.CurrentPage ?? Application.Current?.MainPage;
+            if (currentPage is null)
+            {
+                SetStatus("Unable to launch the photo picker UI.", true);
+                return;
+            }
+
+            string? selection = await MainThread.InvokeOnMainThreadAsync(() =>
+                currentPage.DisplayActionSheet(
+                    "Update Profile Picture",
+                    cancelOption,
+                    null,
+                    takePhotoOption,
+                    chooseFromGalleryOption));
+
+            if (string.IsNullOrWhiteSpace(selection) || selection.Equals(cancelOption, StringComparison.Ordinal))
+            {
+                return;
+            }
+
+            FileResult? photo = null;
+
+            if (selection.Equals(takePhotoOption, StringComparison.Ordinal))
+            {
+                if (!MediaPicker.Default.IsCaptureSupported)
+                {
+                    SetStatus("Capturing photos is not supported on this device.", true);
+                    return;
+                }
+
+                PermissionStatus cameraStatus = await Permissions.CheckStatusAsync<Permissions.Camera>();
+                if (cameraStatus != PermissionStatus.Granted)
+                {
+                    cameraStatus = await Permissions.RequestAsync<Permissions.Camera>();
+                }
+
+                if (cameraStatus != PermissionStatus.Granted)
+                {
+                    SetStatus("Camera permission is required to take a profile photo.", true);
+                    return;
+                }
+
+                photo = await MediaPicker.CapturePhotoAsync();
+            }
+            else if (selection.Equals(chooseFromGalleryOption, StringComparison.Ordinal))
+            {
+                photo = await MediaPicker.PickPhotoAsync();
+            }
+
             if (photo is not null)
             {
                 ProfilePicturePath = photo.FullPath;
                 SetStatus("Profile picture updated.", false);
             }
+        }
+        catch (FeatureNotSupportedException ex)
+        {
+            SetStatus($"Photo capture not supported: {ex.Message}", true);
+        }
+        catch (PermissionException ex)
+        {
+            SetStatus($"Required permissions were denied: {ex.Message}", true);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
## Summary
- disable Android backups, block cleartext traffic, and scope legacy storage access to API 32 and below
- request camera permission only when the user opts to capture a new profile photo and handle unsupported scenarios gracefully

## Testing
- not run (MAUI Android build requires workloads not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68dba6ee4bbc8326b27bb1eb5a856850